### PR TITLE
Add Prometheus metrics

### DIFF
--- a/src/redis-shake/metric/metric.go
+++ b/src/redis-shake/metric/metric.go
@@ -3,7 +3,6 @@ package metric
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -50,18 +49,9 @@ func (p *Percent) Get(returnString bool) interface{} {
 		if returnString {
 			return fmt.Sprintf("%.02f", float64(dividend)/float64(divisor))
 		} else {
-			return dividend / divisor
+			return float64(dividend) / float64(divisor)
 		}
 	}
-}
-
-func (p *Percent) GetFloat64() float64 {
-	divisor := atomic.LoadUint64(&p.Divisor)
-	if divisor == 0 {
-		return math.MaxFloat64
-	}
-	dividend := atomic.LoadUint64(&p.Dividend)
-	return float64(dividend) / float64(divisor)
 }
 
 func (p *Percent) Update() {
@@ -235,7 +225,7 @@ func (m *Metric) GetAvgDelay() interface{} {
 }
 
 func (m *Metric) GetAvgDelayFloat64() float64 {
-	return m.AvgDelay.GetFloat64()
+	return m.AvgDelay.Get(false).(float64)
 }
 
 func (m *Metric) AddNetworkFlow(dbSyncerID int, val uint64) {

--- a/src/redis-shake/metric/prometheus_metrics.go
+++ b/src/redis-shake/metric/prometheus_metrics.go
@@ -9,60 +9,72 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const (
+	metricNamespace = "redisshake"
+)
+
 var (
 	pullCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "pull_cmd_count_total",
-			Help: "RedisShake pull redis cmd count in total",
+			Namespace: metricNamespace,
+			Name:      "pull_cmd_count_total",
+			Help:      "RedisShake pull redis cmd count in total",
 		},
 		[]string{"dbSyncer"},
 	)
 	bypassCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "bypass_cmd_count_total",
-			Help: "RedisShake bypass redis cmd count in total",
+			Namespace: metricNamespace,
+			Name:      "bypass_cmd_count_total",
+			Help:      "RedisShake bypass redis cmd count in total",
 		},
 		[]string{"dbSyncer"},
 	)
 	pushCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "push_cmd_count_total",
-			Help: "RedisShake push redis cmd count in total",
+			Namespace: metricNamespace,
+			Name:      "push_cmd_count_total",
+			Help:      "RedisShake push redis cmd count in total",
 		},
 		[]string{"dbSyncer"},
 	)
 	successCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "success_cmd_count_total",
-			Help: "RedisShake push redis cmd count in total",
+			Namespace: metricNamespace,
+			Name:      "success_cmd_count_total",
+			Help:      "RedisShake push redis cmd count in total",
 		},
 		[]string{"dbSyncer"},
 	)
 	failCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "fail_cmd_count_total",
-			Help: "RedisShake push redis cmd count in total",
+			Namespace: metricNamespace,
+			Name:      "fail_cmd_count_total",
+			Help:      "RedisShake push redis cmd count in total",
 		},
 		[]string{"dbSyncer"},
 	)
 	networkFlowTotalInBytes = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "network_flow_total_in_bytes",
-			Help: "RedisShake total network flow in total (byte)",
+			Namespace: metricNamespace,
+			Name:      "network_flow_total_in_bytes",
+			Help:      "RedisShake total network flow in total (byte)",
 		},
 		[]string{"dbSyncer"},
 	)
 	fullSyncProcessPercent = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "full_sync_process_percent",
-			Help: "RedisShake full sync process (%)",
+			Namespace: metricNamespace,
+			Name:      "full_sync_process_percent",
+			Help:      "RedisShake full sync process (%)",
 		},
 		[]string{"dbSyncer"},
 	)
 	averageDelayInMs = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "average_delay_in_ms",
-			Help: "RedisShake average delay (ms)",
+			Namespace: metricNamespace,
+			Name:      "average_delay_in_ms",
+			Help:      "RedisShake average delay (ms)",
 		},
 		[]string{"dbSyncer"},
 	)

--- a/src/redis-shake/metric/prometheus_metrics.go
+++ b/src/redis-shake/metric/prometheus_metrics.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	metricNamespace = "redisshake"
+	metricNamespace   = "redisshake"
+	dbSyncerLabelName = "db_syncer"
 )
 
 var (
@@ -20,7 +21,7 @@ var (
 			Name:      "pull_cmd_count_total",
 			Help:      "RedisShake pull redis cmd count in total",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	bypassCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -28,7 +29,7 @@ var (
 			Name:      "bypass_cmd_count_total",
 			Help:      "RedisShake bypass redis cmd count in total",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	pushCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -36,7 +37,7 @@ var (
 			Name:      "push_cmd_count_total",
 			Help:      "RedisShake push redis cmd count in total",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	successCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -44,7 +45,7 @@ var (
 			Name:      "success_cmd_count_total",
 			Help:      "RedisShake push redis cmd count in total",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	failCmdCountTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -52,7 +53,7 @@ var (
 			Name:      "fail_cmd_count_total",
 			Help:      "RedisShake push redis cmd count in total",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	networkFlowTotalInBytes = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -60,7 +61,7 @@ var (
 			Name:      "network_flow_total_in_bytes",
 			Help:      "RedisShake total network flow in total (byte)",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	fullSyncProcessPercent = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -68,7 +69,7 @@ var (
 			Name:      "full_sync_process_percent",
 			Help:      "RedisShake full sync process (%)",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 	averageDelayInMs = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -76,7 +77,7 @@ var (
 			Name:      "average_delay_in_ms",
 			Help:      "RedisShake average delay (ms)",
 		},
-		[]string{"dbSyncer"},
+		[]string{dbSyncerLabelName},
 	)
 )
 

--- a/src/redis-shake/metric/prometheus_metrics.go
+++ b/src/redis-shake/metric/prometheus_metrics.go
@@ -1,0 +1,82 @@
+package metric
+
+import (
+	"strconv"
+
+	"redis-shake/common"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	pullCmdCountTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pull_cmd_count_total",
+			Help: "RedisShake pull redis cmd count in total",
+		},
+		[]string{"dbSyncer"},
+	)
+	bypassCmdCountTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bypass_cmd_count_total",
+			Help: "RedisShake bypass redis cmd count in total",
+		},
+		[]string{"dbSyncer"},
+	)
+	pushCmdCountTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "push_cmd_count_total",
+			Help: "RedisShake push redis cmd count in total",
+		},
+		[]string{"dbSyncer"},
+	)
+	successCmdCountTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "success_cmd_count_total",
+			Help: "RedisShake push redis cmd count in total",
+		},
+		[]string{"dbSyncer"},
+	)
+	failCmdCountTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fail_cmd_count_total",
+			Help: "RedisShake push redis cmd count in total",
+		},
+		[]string{"dbSyncer"},
+	)
+	networkFlowTotalInBytes = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "network_flow_total_in_bytes",
+			Help: "RedisShake total network flow in total (byte)",
+		},
+		[]string{"dbSyncer"},
+	)
+	fullSyncProcessPercent = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "full_sync_process_percent",
+			Help: "RedisShake full sync process (%)",
+		},
+		[]string{"dbSyncer"},
+	)
+	averageDelayInMs = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "average_delay_in_ms",
+			Help: "RedisShake average delay (ms)",
+		},
+		[]string{"dbSyncer"},
+	)
+)
+
+// CalcPrometheusMetrics calculates some prometheus metrics e.g. average delay.
+func CalcPrometheusMetrics() {
+	total := utils.GetTotalLink()
+	for i := 0; i < total; i++ {
+		val, ok := MetricMap.Load(i)
+		if !ok {
+			continue
+		}
+		singleMetric := val.(*Metric)
+		averageDelayInMs.WithLabelValues(strconv.Itoa(i)).Set(singleMetric.GetAvgDelayFloat64())
+	}
+}

--- a/src/redis-shake/restful/restful.go
+++ b/src/redis-shake/restful/restful.go
@@ -1,19 +1,30 @@
 package restful
 
 import (
-	"github.com/gugemichael/nimo4go"
-	"redis-shake/metric"
+	"net/http"
 	"redis-shake/common"
+	"redis-shake/metric"
+
+	"github.com/gugemichael/nimo4go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // register all rest api
 func RestAPI() {
-	registerMetric() // register metric
+	registerMetric()           // register metric
+	registerPrometheusMetric() // register prometheus metrics
 	// add below if has more
 }
 
 func registerMetric() {
 	utils.HttpApi.RegisterAPI("/metric", nimo.HttpGet, func([]byte) interface{} {
 		return metric.NewMetricRest()
+	})
+}
+
+func registerPrometheusMetric() {
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+		metric.CalcPrometheusMetrics()
+		promhttp.Handler().ServeHTTP(w, req)
 	})
 }

--- a/src/redis-shake/sync.go
+++ b/src/redis-shake/sync.go
@@ -467,14 +467,14 @@ func (ds *dbSyncer) syncRDBFile(reader *bufio.Reader, target []string, auth_type
 			fmt.Fprintf(&b, "  ignore=%-12d", stat.ignore)
 		}
 		log.Info(b.String())
-		metric.GetMetric(ds.id).SetFullSyncProgress(uint64(100 * stat.rbytes / nsize))
+		metric.GetMetric(ds.id).SetFullSyncProgress(ds.id, uint64(100*stat.rbytes/nsize))
 	}
 	log.Infof("dbSyncer[%v] sync rdb done", ds.id)
 }
 
 func (ds *dbSyncer) syncCommand(reader *bufio.Reader, target []string, auth_type, passwd string, tlsEnable bool) {
-	readeTimeout := time.Duration(10)*time.Minute
-	writeTimeout := time.Duration(10)*time.Minute
+	readeTimeout := time.Duration(10) * time.Minute
+	writeTimeout := time.Duration(10) * time.Minute
 	isCluster := conf.Options.TargetType == conf.RedisTypeCluster
 	c := utils.OpenRedisConnWithTimeout(target, auth_type, passwd, readeTimeout, writeTimeout, isCluster, tlsEnable)
 	defer c.Close()
@@ -538,9 +538,9 @@ func (ds *dbSyncer) syncCommand(reader *bufio.Reader, target []string, auth_type
 			}
 
 			if err == nil {
-				metric.GetMetric(ds.id).AddSuccessCmdCount(1)
+				metric.GetMetric(ds.id).AddSuccessCmdCount(ds.id, 1)
 			} else {
-				metric.GetMetric(ds.id).AddFailCmdCount(1)
+				metric.GetMetric(ds.id).AddFailCmdCount(ds.id, 1)
 				if utils.CheckHandleNetError(err) {
 					log.Panicf("dbSyncer[%v] Event:NetErrorWhileReceive\tId:%s\tError:%s",
 						ds.id, conf.Options.Id, err.Error())
@@ -592,7 +592,7 @@ func (ds *dbSyncer) syncCommand(reader *bufio.Reader, target []string, auth_type
 			if scmd, argv, err = redis.ParseArgs(resp); err != nil {
 				log.PanicErrorf(err, "dbSyncer[%v] parse command arguments failed", ds.id)
 			} else {
-				metric.GetMetric(ds.id).AddPullCmdCount(1)
+				metric.GetMetric(ds.id).AddPullCmdCount(ds.id, 1)
 
 				// print debug log of send command
 				if conf.Options.LogLevel == utils.LogLevelAll {
@@ -622,7 +622,7 @@ func (ds *dbSyncer) syncCommand(reader *bufio.Reader, target []string, auth_type
 					if bypass || ignorecmd {
 						ds.nbypass.Incr()
 						// ds.SyncStat.BypassCmdCount.Incr()
-						metric.GetMetric(ds.id).AddBypassCmdCount(1)
+						metric.GetMetric(ds.id).AddBypassCmdCount(ds.id, 1)
 						log.Debugf("dbSyncer[%v] ignore command[%v]", ds.id, scmd)
 						continue
 					}
@@ -657,7 +657,7 @@ func (ds *dbSyncer) syncCommand(reader *bufio.Reader, target []string, auth_type
 					ds.sendBuf <- cmdDetail{Cmd: "SELECT", Args: [][]byte{[]byte(strconv.FormatInt(int64(lastdb), 10))}}
 				} else {
 					ds.nbypass.Incr()
-					metric.GetMetric(ds.id).AddBypassCmdCount(1)
+					metric.GetMetric(ds.id).AddBypassCmdCount(ds.id, 1)
 				}
 				continue
 			}
@@ -685,8 +685,8 @@ func (ds *dbSyncer) syncCommand(reader *bufio.Reader, target []string, auth_type
 
 			ds.forward.Incr()
 			ds.wbytes.Add(int64(length))
-			metric.GetMetric(ds.id).AddPushCmdCount(1)
-			metric.GetMetric(ds.id).AddNetworkFlow(uint64(length))
+			metric.GetMetric(ds.id).AddPushCmdCount(ds.id, 1)
+			metric.GetMetric(ds.id).AddNetworkFlow(ds.id, uint64(length))
 			sendId.Incr()
 
 			if conf.Options.Metric {

--- a/src/vendor/vendor.json
+++ b/src/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2017-12-04T08:54:13Z"
 		},
 		{
+			"checksumSHA1": "0rido7hYHQtfq3UJzVT5LClLAWc=",
+			"path": "github.com/beorn7/perks/quantile",
+			"revision": "4b2b341e8d7715fae06375aa633dbb6e91b3fb46",
+			"revisionTime": "2019-04-14T22:11:40Z"
+		},
+		{
 			"checksumSHA1": "1/Kf0ihi6RtfNt0JjAtZLKvfqJY=",
 			"path": "github.com/cupcake/rdb",
 			"revision": "43ba34106c765f2111c0dc7b74cdf8ee437411e0",
@@ -51,10 +57,22 @@
 			"revisionTime": "2018-04-04T16:07:26Z"
 		},
 		{
+			"checksumSHA1": "CGj8VcI/CpzxaNqlqpEVM7qElD4=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "b285ee9cfc6c881bb20c0d8dc73370ea9b9ec90f",
+			"revisionTime": "2019-05-17T06:12:10Z"
+		},
+		{
 			"checksumSHA1": "63olncsMU/K9MMKxt4zuKSyoNg0=",
 			"path": "github.com/gugemichael/nimo4go",
 			"revision": "cbcfac21339d78efaed9ed09dcba7296d9976118",
 			"revisionTime": "2018-09-04T03:08:18Z"
+		},
+		{
+			"checksumSHA1": "bKMZjd2wPw13VwoE7mBeSv5djFA=",
+			"path": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"revision": "c182affec369e30f25d3eb8cd8a478dee585ae7d",
+			"revisionTime": "2018-12-31T17:19:20Z"
 		},
 		{
 			"checksumSHA1": "W7TFJ3aRSUenZvYVnzrOZPoIOjs=",
@@ -91,6 +109,42 @@
 			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
 			"revision": "3d8379da8fc2309dd563f593f15a739054c098bc",
 			"revisionTime": "2019-06-17T18:27:57Z"
+		},
+		{
+			"checksumSHA1": "V8xkqgmP66sq2ZW4QO5wi9a4oZE=",
+			"path": "github.com/prometheus/client_model/go",
+			"revision": "fd36f4220a901265f90734c3183c5f0c91daa0b8",
+			"revisionTime": "2019-01-29T23:31:27Z"
+		},
+		{
+			"checksumSHA1": "ljxJzXiQ7dNsmuRIUhqqP+qjRWc=",
+			"path": "github.com/prometheus/common/expfmt",
+			"revision": "31bed53e4047fd6c510e43a941f90cb31be0972a",
+			"revisionTime": "2019-06-17T21:11:42Z"
+		},
+		{
+			"checksumSHA1": "1Mhfofk+wGZ94M0+Bd98K8imPD4=",
+			"path": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
+			"revision": "31bed53e4047fd6c510e43a941f90cb31be0972a",
+			"revisionTime": "2019-06-17T21:11:42Z"
+		},
+		{
+			"checksumSHA1": "ccmMs+h9Jo8kE7izqsUkWShD4d0=",
+			"path": "github.com/prometheus/common/model",
+			"revision": "31bed53e4047fd6c510e43a941f90cb31be0972a",
+			"revisionTime": "2019-06-17T21:11:42Z"
+		},
+		{
+			"checksumSHA1": "L4ayL3hh390Bk5vmXgtNGo9d/rc=",
+			"path": "github.com/prometheus/procfs",
+			"revision": "90b65b6334013b0a1cfce27ce5c79feb7da2f77a",
+			"revisionTime": "2019-06-14T00:01:41Z"
+		},
+		{
+			"checksumSHA1": "Kmjs49lbjGmlgUPx3pks0tVDed0=",
+			"path": "github.com/prometheus/procfs/internal/fs",
+			"revision": "90b65b6334013b0a1cfce27ce5c79feb7da2f77a",
+			"revisionTime": "2019-06-14T00:01:41Z"
 		},
 		{
 			"checksumSHA1": "Tutue3nEgM/87jitUcYv6ODwyNE=",

--- a/src/vendor/vendor.json
+++ b/src/vendor/vendor.json
@@ -69,6 +69,24 @@
 			"revisionTime": "2018-12-26T10:54:42Z"
 		},
 		{
+			"checksumSHA1": "x5CuZuHwidIOrzy/g2NQMDJMIxQ=",
+			"path": "github.com/prometheus/client_golang/prometheus",
+			"revision": "3d8379da8fc2309dd563f593f15a739054c098bc",
+			"revisionTime": "2019-06-17T18:27:57Z"
+		},
+		{
+			"checksumSHA1": "BFMAsj5z3cYaNKx9fwHrazQRFvI=",
+			"path": "github.com/prometheus/client_golang/prometheus/promauto",
+			"revision": "3d8379da8fc2309dd563f593f15a739054c098bc",
+			"revisionTime": "2019-06-17T18:27:57Z"
+		},
+		{
+			"checksumSHA1": "V51yx4gq61QCD9clxnps792Eq2Y=",
+			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
+			"revision": "3d8379da8fc2309dd563f593f15a739054c098bc",
+			"revisionTime": "2019-06-17T18:27:57Z"
+		},
+		{
 			"checksumSHA1": "Tutue3nEgM/87jitUcYv6ODwyNE=",
 			"path": "github.com/satori/go.uuid",
 			"revision": "b2ce2384e17bbe0c6d34077efa39dbab3e09123b",
@@ -92,6 +110,5 @@
 			"revision": "a96e63847dc3c67d17befa69c303767e2f84e54f",
 			"revisionTime": "2017-05-31T16:03:50Z"
 		}
-	],
-	"rootPath": "/Users/vinllen-ali/code/redis-shake-inner/redis-shake/src"
+	]
 }

--- a/src/vendor/vendor.json
+++ b/src/vendor/vendor.json
@@ -75,6 +75,12 @@
 			"revisionTime": "2019-06-17T18:27:57Z"
 		},
 		{
+			"checksumSHA1": "UBqhkyjCz47+S19MVTigxJ2VjVQ=",
+			"path": "github.com/prometheus/client_golang/prometheus/internal",
+			"revision": "3d8379da8fc2309dd563f593f15a739054c098bc",
+			"revisionTime": "2019-06-17T18:27:57Z"
+		},
+		{
 			"checksumSHA1": "BFMAsj5z3cYaNKx9fwHrazQRFvI=",
 			"path": "github.com/prometheus/client_golang/prometheus/promauto",
 			"revision": "3d8379da8fc2309dd563f593f15a739054c098bc",


### PR DESCRIPTION
fix #81 
Add prometheus metrics
```
redisshake_average_delay_in_ms
redisshake_bypass_cmd_count_total
redisshake_fail_cmd_count_total
redisshake_full_sync_process_percent
redisshake_network_flow_total_in_bytes
redisshake_pull_cmd_count_total
redisshake_push_cmd_count_total
redisshake_success_cmd_count_total
```
e.g.
```
# HELP redisshake_average_delay_in_ms RedisShake average delay (ms)
# TYPE redisshake_average_delay_in_ms gauge
redisshake_average_delay_in_ms{db_syncer="0"} 22.556124264360903
# HELP redisshake_full_sync_process_percent RedisShake full sync process (%)
# TYPE redisshake_full_sync_process_percent gauge
redisshake_full_sync_process_percent{db_syncer="0"} 100
# HELP redisshake_network_flow_total_in_bytes RedisShake total network flow in total (byte)
# TYPE redisshake_network_flow_total_in_bytes counter
redisshake_network_flow_total_in_bytes{db_syncer="0"} 1.35214258e+08
# HELP redisshake_pull_cmd_count_total RedisShake pull redis cmd count in total
# TYPE redisshake_pull_cmd_count_total counter
redisshake_pull_cmd_count_total{db_syncer="0"} 635990
# HELP redisshake_push_cmd_count_total RedisShake push redis cmd count in total
# TYPE redisshake_push_cmd_count_total counter
redisshake_push_cmd_count_total{db_syncer="0"} 635990
# HELP redisshake_success_cmd_count_total RedisShake push redis cmd count in total
# TYPE redisshake_success_cmd_count_total counter
redisshake_success_cmd_count_total{db_syncer="0"} 635162
```