### PR TITLE
fix enable automatic discovery with '@'

### DIFF
--- a/src/redis-shake/common/configure.go
+++ b/src/redis-shake/common/configure.go
@@ -108,7 +108,7 @@ func parseAddress(tp, address, redisType string, isSource bool) error {
 			if isSource && arr[0] != conf.StandAloneRoleSlave && arr[0] != conf.StandAloneRoleMaster {
 				return fmt.Errorf("source redis role must be master or slave, when enable automatic discovery with '@'")
 			}
-			if !isSource && arr[0] != "master" {
+			if !isSource && arr[0] != "master" && arr[0] != "" {
 				return fmt.Errorf("target redis role must be master, when enable automatic discovery with '@'")
 			}
 

--- a/src/redis-shake/common/configure.go
+++ b/src/redis-shake/common/configure.go
@@ -106,10 +106,10 @@ func parseAddress(tp, address, redisType string, isSource bool) error {
 			}
 
 			if isSource && arr[0] != conf.StandAloneRoleSlave && arr[0] != conf.StandAloneRoleMaster {
-				return fmt.Errorf("redis role must be master or slave")
+				return fmt.Errorf("source redis role must be master or slave, when enable automatic discovery with '@'")
 			}
-			if !isSource && arr[0] != "" {
-				return fmt.Errorf("redis type[%v] leading character must be '@'", redisType)
+			if !isSource && arr[0] != "master" {
+				return fmt.Errorf("target redis role must be master, when enable automatic discovery with '@'")
 			}
 
 			clusterList := strings.Split(arr[1], AddressClusterSplitter)


### PR DESCRIPTION
### [3.2 集群版cluster到集群版cluster配置举例](https://github.com/alibaba/RedisShake/wiki/%E7%AC%AC%E4%B8%80%E6%AC%A1%E4%BD%BF%E7%94%A8%EF%BC%8C%E5%A6%82%E4%BD%95%E8%BF%9B%E8%A1%8C%E9%85%8D%E7%BD%AE%EF%BC%9F#32-%E9%9B%86%E7%BE%A4%E7%89%88cluster%E5%88%B0%E9%9B%86%E7%BE%A4%E7%89%88cluster%E9%85%8D%E7%BD%AE%E4%B8%BE%E4%BE%8B)：
。。。对于target.address，只能是master或者不配置。。。